### PR TITLE
Upgrade to MonoGame 3.8.2.*

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,34 +3,39 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.263",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
-      ]
+      ],
+      "rollForward": false
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.263",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
-      ]
+      ],
+      "rollForward": false
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.263",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
-      ]
+      ],
+      "rollForward": false
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.263",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
-      ]
+      ],
+      "rollForward": false
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.263",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# MonoGame Content Builder
+.mgstats

--- a/FontExtension/BracketHouse.FontExtension.csproj
+++ b/FontExtension/BracketHouse.FontExtension.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0-windows</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ApplicationIcon />
 		<OutputType>Library</OutputType>
 		<StartupObject />
@@ -29,10 +29,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MonoGame.Framework.Content.Pipeline" Version="3.8.1.*">
+		<PackageReference Include="MonoGame.Framework.Content.Pipeline" Version="3.8.2.1105">
 			<PrivateAssets>All</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.*">
+		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105">
 			<PrivateAssets>All</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>

--- a/MonoMSDF/Content/Content.mgcb
+++ b/MonoMSDF/Content/Content.mgcb
@@ -10,7 +10,7 @@
 
 #-------------------------------- References --------------------------------#
 
-/reference:..\..\FontExtension\bin\Debug\netcoreapp3.1\BracketHouse.FontExtension.dll
+/reference:..\..\FontExtension\bin\Debug\net8.0\BracketHouse.FontExtension.dll
 
 #---------------------------------- Content ---------------------------------#
 

--- a/MonoMSDF/MonoMSDF.csproj
+++ b/MonoMSDF/MonoMSDF.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net8.0-windows</TargetFramework>

--- a/MonoMSDF/MonoMSDF.csproj
+++ b/MonoMSDF/MonoMSDF.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net6.0-windows</TargetFramework>
+		<TargetFramework>net8.0-windows</TargetFramework>
 		<PublishReadyToRun>false</PublishReadyToRun>
 		<TieredCompilation>false</TieredCompilation>
 		<UseWindowsForms>true</UseWindowsForms>
@@ -17,8 +17,8 @@
 		<MonoGameContentReference Include="Content\Content.mgcb" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.*" />
-	  <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.*" />
+	  <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.*" />
+	  <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.2.*" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\FontExtension\BracketHouse.FontExtension.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
Just a simple PR to upgrade to .MonoGame 3.8.2.* and .NET 8.

I was trying to use this in a new MonoGame project, and kept getting this error: `This MGFX effect is for an older release of MonoGame and needs to be rebuilt.` This should resolve that (once a new package version is released).

---

EDIT: on another topic, I would love to be able to set z depth when rendering text with this library. I see that [there are some overloads](https://github.com/Peewi/BracketHouse.FontExtension/blob/master/FontExtension/TextRenderer.cs#L194) which accept such a parameter, but they're private. Some public surface area would be great.

Apologies for asking this in a pull request, but this repo does not have GitHub issues enabled.